### PR TITLE
Add policy templates and generation mechanism

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,11 @@
 ssh-key-*
 secrets*
 k8s-deploy-venv/*
-values.yaml
 */Chart.lock
 */charts/*
+
+# Generated from templates
+values.yaml
+*/policy/config-*.yaml
+**/templates/privacy-policy.html
+**/templates/terms-of-use.html

--- a/README.md
+++ b/README.md
@@ -185,6 +185,16 @@ Helm is a package manager for Kubernetes, and it is used to install JupyterHub.
 curl https://raw.githubusercontent.com/helm/helm/HEAD/scripts/get-helm-3 | bash
 ```
 
+## Generating policy documents for an AiiDAlab deployment
+
+In the `basehub/policy` folder:
+
+- Copy `config.yaml` as `config-<deployment-name>.yaml`
+- Fill out the required variables in the new config file
+- Run `./generate.sh` to generate the policy documents
+
+See `basehub/policy/README.md` for more information.
+
 ## Install JupyterHub
 
 Running the helm command will install JupyterHub with the configuration in `values.yaml`.

--- a/README.md
+++ b/README.md
@@ -123,7 +123,6 @@ az aks update-credentials \
  --client-secret <NewClientSecret>
 ```
 
-
 The auto-scaler will scale the number of nodes in the cluster between 3 and 6, based on the CPU and memory usage of the pods.
 It can be updated later with the following command:
 
@@ -189,9 +188,8 @@ curl https://raw.githubusercontent.com/helm/helm/HEAD/scripts/get-helm-3 | bash
 
 In the `basehub/policy` folder:
 
-- Copy `config.yaml` as `config-<deployment-name>.yaml`
-- Fill out the required variables in the new config file
-- Run `./generate.sh` to generate the policy documents
+- Fill out the required variables in `config.yaml`
+- Run `source generate.sh` to generate the policy documents
 
 See `basehub/policy/README.md` for more information.
 
@@ -217,10 +215,10 @@ jinja2 --format=env basehub/values.yaml.j2 > basehub/values.yaml
 
 The following environment variables are required to be set:
 
-* `K8S_NAMESPACE`: The namespace where the JupyterHub will be installed, e.g. `production`, `staging`.
-* `OAUTH_CLIENT_ID`: The client ID of the GitHub app.
-* `OAUTH_CLIENT_SECRET`: The client secret of the GitHub app.
-* `OAUTH_CALLBACK_URL`: The callback URL of the GitHub app.
+- `K8S_NAMESPACE`: The namespace where the JupyterHub will be installed, e.g. `production`, `staging`.
+- `OAUTH_CLIENT_ID`: The client ID of the GitHub app.
+- `OAUTH_CLIENT_SECRET`: The client secret of the GitHub app.
+- `OAUTH_CALLBACK_URL`: The callback URL of the GitHub app.
 
 We use GitHub oauthenticator, the users will be able to login with their GitHub account.
 The authentication is created using the `aiidalab` org with app name `aiidalab-demo-production` and `aiidalab-demo-staging` for the production and staging environments respectively.
@@ -239,7 +237,6 @@ The IP address of proxy-public service can be retrieved with the following comma
 kubectl get svc proxy-public -n <namespace>
 ```
 
-
 ## For maintainers and administrators
 
 ### Automatic CI/CD deployment
@@ -247,7 +244,7 @@ kubectl get svc proxy-public -n <namespace>
 We simply run helm upgrade in CI workflow to deploy the JupyterHub.
 The CI workflow requires login to the Azure account, and we use OpenID Connect to authenticate the user.
 
-Go to the entra.microsoft.com and navigate to the `aiidalab-sp` -> `Certificates & secrets` -> `Fedrated credentials`. Set credentials for the GitHub production and staging environments. 
+Go to the entra.microsoft.com and navigate to the `aiidalab-sp` -> `Certificates & secrets` -> `Fedrated credentials`. Set credentials for the GitHub production and staging environments.
 
 On the GitHub repository, the secrets are set for `production` and `staging` environments respectively.
 
@@ -270,4 +267,3 @@ proxy:
     letsencrypt:
       contactEmail: <your-email-address>
 ```
-

--- a/basehub/files/etc/jupyterhub/templates/page.html
+++ b/basehub/files/etc/jupyterhub/templates/page.html
@@ -39,6 +39,10 @@
 
             {# Start AiiDAlab specific change #}
             <li><a href="{{base_url}}about">About</a></li>
+            {% if include_policies %}
+            <li><a href="{{base_url}}terms-of-use">Terms of use</a></li>
+            <li><a href="{{base_url}}privacy-policy">Privacy policy</a></li>
+            {% endif %}
             <li><a href="{{base_url}}faq">FAQ</a></li>
             {# End change #}
 
@@ -49,6 +53,10 @@
         {% else %}
         <ul class="nav navbar-nav">
           <li><a href="{{base_url}}about">About</a></li>
+          {% if include_policies %}
+          <li><a href="{{base_url}}terms-of-use">Terms of use</a></li>
+          <li><a href="{{base_url}}privacy-policy">Privacy policy</a></li>
+          {% endif %}
           <li><a href="{{base_url}}faq">FAQ</a></li>
         </ul>
         {# End change #}

--- a/basehub/policy/README.md
+++ b/basehub/policy/README.md
@@ -20,3 +20,7 @@ To generate the policy documents, follow these steps:
 3. run `source generate.sh`
 
 The `generate.sh` script also sets the environment variable `INCLUDE_POLICIES` to `True`, which is used in the `values.yaml` and `page.html` templates to enable the policy navigation items.
+
+### Note regarding location
+
+The documents were defined initially at EPFL and include Swiss/Lausanne-specific items. If you do opt to include these policies, please ensure that they are relevant to your deployment and location.

--- a/basehub/policy/README.md
+++ b/basehub/policy/README.md
@@ -1,0 +1,22 @@
+# Generating policy documents for an AiiDAlab deployment
+
+This document describes how to generate policy documents for an AiiDAlab deployment.
+The policy documents are used to define the access control policies for the AiiDAlab deployment.
+
+This folder includes the following policy document templates:
+
+- `terms-of-use.j2`: The terms of use policy document template.
+- `privacy-policy.j2`: The privacy policy document template.
+
+The folder also includes the following:
+
+- `config.yaml`: a file containing the template variables
+- `generate.sh`: a script to generate the policy documents from the config file
+
+To generate the policy documents, follow these steps:
+
+1. install the requirements with `pip install -r requirements.txt`
+2. fill out the `config.yaml` file with the required information
+3. run `source generate.sh`
+
+The `generate.sh` script also sets the environment variable `INCLUDE_POLICIES` to `True`, which is used in the `values.yaml` and `page.html` templates to enable the policy navigation items.

--- a/basehub/policy/config.yaml
+++ b/basehub/policy/config.yaml
@@ -1,0 +1,22 @@
+---
+version: # the version of the deployed document
+year: # the year associated with the version
+
+# the institution that is deploying AiiDAlab
+institution:
+    name:
+        full: # full name of institution
+        short: # institution acronym
+    address: # institution address
+    description: # short institution description
+
+# the host of the AiiDAlab deployment
+host:
+    name: # the name of the host
+    location: # the physical location of the host
+
+# the contact email for issues with the deployment
+contact_email:
+
+# governing law
+court: # court in charge of this matter

--- a/basehub/policy/generate.sh
+++ b/basehub/policy/generate.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+
+CONFIG=config.yaml
+OUTDIR=../files/etc/jupyterhub/templates
+
+jinja2 --format=yaml terms-of-use.j2 $CONFIG >$OUTDIR/terms-of-use.html
+jinja2 --format=yaml privacy-policy.j2 $CONFIG >$OUTDIR/privacy-policy.html
+
+export INCLUDE_POLICIES=True

--- a/basehub/policy/privacy-policy.j2
+++ b/basehub/policy/privacy-policy.j2
@@ -1,0 +1,151 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>AiiDAlab | Privacy Policy</title>
+    <link
+      href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/css/bootstrap.min.css"
+      rel="stylesheet"
+    />
+  </head>
+  <body>
+    <div class="container mt-5">
+      <h1>
+        AiiDAlab Privacy Policy (Personal Data Protection) v{{ version }},
+        {{ year }}
+      </h1>
+      <div class="container">
+        <h3>Scope and Definitions</h3>
+        <p>
+          This Privacy Policy shall apply to the personal data of the Users
+          collected by AiiDAlab in connection with AiiDAlab Services and to any
+          personal data posted or processed by the Users of AiiDAlab.
+        </p>
+
+        <p>
+          Words in this Privacy Policy shall have the same meaning as defined in
+          Article 2. &ldquo;Definitions&rdquo; of the AiiDAlab Terms of Use.
+        </p>
+        <p></p>
+
+        <h3>Data Controllers</h3>
+        <p>
+          For the personal data of the Users, which are collected by AiiDAlab
+          for the User's account and the operation of the Services by AiiDAlab:
+          <a href="mailto:{{ contact_email }}">{{ contact_email }}</a>
+          on behalf of {{ institution.name.full }}, {{ institution.address }}.
+        </p>
+
+        <p>
+          For any other personal data in particular any personal data posted
+          and/or processed by the Users on AiiDAlab Web site, the respective
+          User shall be the data controller. If you post, collect or otherwise
+          process any personal data on the Website, you shall be solely
+          responsible for the processing of such data in compliance with all
+          applicable legal requirements.
+        </p>
+
+        <h3>Types and Use of Data collected</h3>
+        <p>
+          AiiDAlab collects personal data such as your name, e-mail address and
+          other information you give when creating an account on AiiDAlab
+          website. For operation and maintenance purposes, AiiDAlab may collect
+          files that record interaction with AiiDAlab website (System Logs) or
+          use for this purpose other personal data such as your IP Address.
+        </p>
+        <p>
+          AiiDAlab only uses your personal data for the operation of AiiDAlab
+          website and services as well as to improve AiiDAlab website and
+          services. Other personal data may be collected on AiiDAlab website
+          along dedicated explanation text contextually with any such data
+          collection.
+        </p>
+        <p>
+          AiiDAlab may use your contact data to send you information about
+          AiiDAlab services.
+        </p>
+
+        <h3>Mode and place of processing the personal data</h3>
+        <h4>Methods of processing</h4>
+        <p>
+          AiiDAlab processes the User's personal data in a proper manner and
+          shall take appropriate security measures to prevent unauthorized
+          access, disclosure, modification, or unauthorized destruction of the
+          data.
+        </p>
+
+        <h4>Place</h4>
+        <p>
+          AiiDAlab computing infrastructure is hosted at
+          {{ host.name }} in {{ host.location }}; hence, your personal data
+          processed by AiiDAlab is stored at said place. If you access to the
+          Services from outside of Switzerland, you understand that your data is
+          then transferred abroad. For further information, please contact the
+          data Controller as indicated above.
+        </p>
+
+        <h4>Retention time</h4>
+        <p>
+          The personal data processed by AiiDAlab is kept as long as you or
+          AiiDAlab has not cancelled your account though AiiDAlab may keep the
+          data after cancellation of your account as long as necessary for
+          technical reasons (like backups) or to comply with legal requirements.
+        </p>
+
+        <h4>The rights of users</h4>
+        <p>
+          Users have the right, at any time, to know whether their personal data
+          has been stored and can consult the data Controller to learn about
+          their contents and origin, to verify their accuracy or to ask for them
+          to be supplemented, cancelled, updated or corrected, or to block any
+          data held in violation of the law, as well as to oppose their
+          treatment for any and all legitimate reasons. Requests should be sent
+          to the data Controller as set out above.
+        </p>
+
+        <h4>Information not contained in this policy</h4>
+        <p>
+          More details concerning the collection or processing of your personal
+          data by AiiDAlab may be requested from the data Controller at any
+          time. Please see the contact information at the beginning of this
+          document.
+        </p>
+
+        <h4>Changes to this privacy policy</h4>
+        <p>
+          AiiDAlab reserves the right to make changes to this privacy policy at
+          any time by giving notice to the users or organizers on this page. It
+          is strongly recommended to check this page often. If a user or
+          organizer disagrees to any of the changes to the Policy, she/he must
+          cease using AiiDAlab website and services and can request that the
+          data Controller removes her/his personal data. Such a removal will
+          result in a termination of your account.
+        </p>
+
+        <h4>Users' Warranty and Indemnification</h4>
+        <p>
+          You warrant that if you post on the Website or collect, handle, store,
+          transfer or otherwise process any personal data in connection with the
+          Services, you will do so in compliance with all applicable laws and
+          regulations. You agree to indemnify and hold
+          {{ institution.name.short }}, its partners and any sub-contractors,
+          harmless from and against any and all claims, liabilities, and
+          expenses, including attorneys' fees, arising out of your posting of
+          any personal data on the Website or your processing of any personal
+          data in connection with the Services.
+        </p>
+
+        <h4>Governing Law &mdash; Place of Jurisdiction</h4>
+        <p>
+          This Privacy Policy and any claims raised in connection therewith are
+          governed by Swiss law, without regard to conflict of law provisions.
+          You agree to submit to the exclusive jurisdiction of the cantonal
+          court of
+          {{ court }}.
+        </p>
+      </div>
+    </div>
+    <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/js/bootstrap.bundle.min.js"></script>
+  </body>
+</html>

--- a/basehub/policy/requirements.txt
+++ b/basehub/policy/requirements.txt
@@ -1,0 +1,2 @@
+jinja2-cli~=0.8.0
+pyyaml~=6.0.0

--- a/basehub/policy/terms-of-use.j2
+++ b/basehub/policy/terms-of-use.j2
@@ -1,0 +1,703 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>AiiDAlab | Terms of Use</title>
+    <link
+      href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/css/bootstrap.min.css"
+      rel="stylesheet"
+    />
+  </head>
+  <body>
+    <div class="container mt-5">
+      <h1>AiiDAlab Terms of Use v{{ version }}, {{ year }}</h1>
+      <h3>1. Scope</h3>
+      <p>
+        These Terms of Use are a legally binding agreement among "The
+        Institution" and you and shall apply to your use of the AiiDAlab
+        services.
+      </p>
+      <h3>2. Definitions</h3>
+      <ol>
+        <li>
+          &ldquo;AiiDAlab&rdquo; means a cloud service to manage scientific
+          workflows using the AiiDA framework, mainly in the field of physics,
+          chemistry and materials science.
+        </li>
+        <li>
+          &ldquo;"The Institution"&rdquo; means {{ institution.name.full }},
+          {{ institution.description }}.
+        </li>
+        <li>
+          &ldquo;Terms of Use&rdquo; mean the provisions contained in the
+          present document and any documents referenced in the present document
+          as well as other operating rules and policies that AiiDAlab may
+          publish from time to time on AiiDAlab Website.
+        </li>
+        <li>
+          The &ldquo;Services&rdquo; means the applications, software and
+          services provided by "The Institution" through AiiDAlab.
+        </li>
+        <li>
+          The &ldquo;Website&rdquo; means the AiiDAlab website and all content
+          and Services provided by AiiDAlab at or through the Website.
+        </li>
+        <li>
+          &ldquo;The User&rdquo; means the individual person, company, or
+          organization that has visited or is using the Website or Services;
+          that accesses or uses any part of the account; or that directs the use
+          of the account in the performance of its functions.
+        </li>
+        <li>&ldquo;You&rdquo; or &ldquo;your&rdquo; refer to the User.</li>
+        <li>
+          &ldquo;Content&rdquo; means content featured or displayed through the
+          Website, including without limitation text, data, articles, images,
+          photographs, graphics, software, applications, designs, features, and
+          other materials that are available on the Website or otherwise
+          available through the Services. &ldquo;Content&rdquo; also includes
+          Services. &ldquo;User-Uploaded Content&rdquo; is Content, written or
+          otherwise, created and/or uploaded by Users (including in any private
+          repositories). &ldquo;Your Content&rdquo; is Content that you own.
+        </li>
+        <li>
+          Third Party's Content means any content, including any data, code,
+          parameters, workflow, methods, research results, you did not obtain or
+          create yourself and/or of which you are not the owner or not the sole
+          owner.
+        </li>
+      </ol>
+
+      <h3>3. Accounts</h3>
+      <h4>3.1 Signup Process</h4>
+      <p>
+        In order to be able to use the Services, you need to request and be
+        granted an account. To that effect you must provide AiiDAlab with the
+        following information:
+      </p>
+      <ol>
+        <li>
+          if You are an individual acting for yourself (i.e. not acting as an
+          officer, manager, director etc of a company or other entity):
+          <ul>
+            <li>Your name and first name</li>
+            <li>Your email address</li>
+          </ul>
+        </li>
+        <li>
+          if You act on behalf of a university, company or other entity:
+          <ul>
+            <li>Your name and first name</li>
+            <li>Your position in the company or entity</li>
+            <li>The name of the company or entity</li>
+          </ul>
+        </li>
+      </ol>
+      <p>
+        If you do act on behalf of a university, company or other entity, you
+        hereby confirm that you have the right to act on behalf of such entity.
+        Upon approval of your account request by AiiDAlab, you will need to
+        accept this Agreement. Your account will then be activated. You hereby
+        warrant that the information you give is true and accurate. Each account
+        is a single user account. Therefore, if more than one user at a company
+        or other entity wish to use the Services, then each user shall have an
+        account.
+      </p>
+
+      <h4>3.2 Your Personal Data</h4>
+      <p>
+        "The Institution" will use your personal data provided to AiiDAlab only
+        for the purpose of operating the Website and the Services; you hereby
+        agree to such processing. "The Institution" shall process and handle
+        said personal data in compliance with the applicable laws and
+        regulations and in accordance with AiiDAlab Privacy Policy.
+      </p>
+
+      <h4>3.3 User Responsibility for Account Security</h4>
+      <p>
+        You are responsible for keeping your account secure. In particular you
+        shall not disclose to others your account identification and password
+        and shall protect that information from access by others.
+      </p>
+      <p>
+        For the avoidance of doubt, "The Institution" shall in no case be liable
+        for any loss or damage arising from your failure to comply with your
+        security obligations.
+      </p>
+      <p>
+        You will promptly notify "The Institution" through AiiDAlab Website if
+        you become aware of any unauthorized access to AiiDAlab Services through
+        your account, including any unauthorized use of your password or
+        account.
+      </p>
+
+      <h4>3.4 User's other Responsibilities and Liability</h4>
+      <h5>3.4.1 Legal Compliance</h5>
+      <p>
+        You are personally responsible for ensuring that your use of the
+        Services does not violate these Terms of Use or any applicable laws and
+        regulations (e.g. criminal laws, data protection laws) or infringes on
+        third parties' rights (including copyrights, database rights, trademark
+        rights, patent rights, license rights and personal rights).
+      </p>
+      <p>
+        In particular, you will not upload, post, host, or transmit any content
+        that:
+      </p>
+      <ul>
+        <li>is unlawful or promotes unlawful activities;</li>
+        <li>violates any personal data protection and/or privacy laws;</li>
+        <li>is defamatory, or fraudulent;</li>
+        <li>is discriminatory or abusive toward any individual or group;</li>
+        <li>
+          infringes on any proprietary right of any party (including copyrights,
+          database rights, trademark rights, patent rights, license rights, and
+          personal rights);
+        </li>
+        <li>
+          violate any agreement you have with third parties (including
+          confidentiality agreements).
+        </li>
+      </ul>
+      <p>
+        You shall abide to the
+        <a
+          href="https://rechtssammlung.sp.ethz.ch/Dokumente/203.21en.pdf"
+          target="_blank"
+          >ETH Zurich Acceptable Use Policy for Telematics Resources (BOT)</a
+        >.
+      </p>
+
+      <h5>3.4.2 Due Care</h5>
+      <p>You shall use the Services with all due care.</p>
+      <p>In particular, you shall not:</p>
+      <ul>
+        <li>
+          use AiiDAlab's servers for any form of excessive automated bulk
+          activity (for example, spamming), or relay any other form of
+          unsolicited advertising or solicitation through our servers, such as
+          get-rich-quick schemes;
+        </li>
+        <li>
+          attempt to disrupt or tamper with AiiDAlab's servers in ways that
+          could harm the Website or Service, to place undue burden on AiiDAlab's
+          servers through automated means, or to access the Services in ways
+          that exceed your authorization, or by uploading content containing
+          malware;
+        </li>
+        <li>
+          impersonate any person or entity, including any of "The Institution"
+          employees or representatives, including through false association with
+          AiiDAlab, or by fraudulently misrepresenting your identity or site's
+          purpose.
+        </li>
+      </ul>
+
+      <h5>3.4.3 No Abuse of the Services</h5>
+      <p>
+        You shall not reproduce, copy, sell, resell or exploit any portion of
+        the Services or the Website without "The Institution"'s express written
+        permission.
+      </p>
+
+      <h5>3.4.4 No Scraping</h5>
+      <p>
+        Scraping refers to extracting data from a website via an automated
+        process, such as a bot or webcrawler. It does not refer to the
+        collection of information through AiiDAlab's API. Please see Section 7
+        for AiiDAlab API Terms. You may scrape the website for the following
+        reasons:
+      </p>
+      <ul>
+        <li>
+          Researchers may scrape public, non-personal information from AiiDAlab
+          for research purposes, only if any publications resulting from that
+          research are open access.
+        </li>
+        <li>
+          Archivists may scrape AiiDAlab for public data for archival purposes.
+        </li>
+      </ul>
+      <p>
+        You may not scrape AiiDAlab for spamming purposes, including for the
+        purposes of selling AiiDAlab users' personal information, such as to
+        recruiters, headhunters, and job boards.
+      </p>
+
+      <h5>3.4.5 Excessive Bandwidth Use</h5>
+      <p>
+        If AiiDAlab determines your bandwidth usage to be significantly
+        excessive in relation to other AiiDAlab users, we reserve the right to
+        suspend your account until you can reduce your bandwidth consumption.
+      </p>
+
+      <h5>3.4.6 Spamming and Inappropriate Use of AiiDAlab</h5>
+      <p>
+        Advertising Content, like all Content, must not violate the law or these
+        Terms of Use, for example through excessive bulk activity such as
+        spamming. "The Institution" reserves the right to remove any
+        advertisements that, in "The Institution"'s sole discretion, violate the
+        Terms of Use or the law.
+      </p>
+
+      <h5>3.4.7 Liability</h5>
+      <p>
+        You and/or the company or entity on behalf of which you use your account
+        shall be liable to "The Institution", the other Users and any others for
+        any damages or claims arising from your unlawful use of the Services or
+        the Website and for any violation of these Terms of Use. You shall
+        indemnify and hold "The Institution", its partners and any
+        sub-contractor harmless against any claims and damages arising from your
+        unlawful use of the Services or the Website or any violation of these
+        Terms of Use.
+      </p>
+
+      <h3>4. User-Uploaded Content</h3>
+      <h4>4.1 User's Responsibility and "The Institution"'s Right to Remove</h4>
+      <p>
+        You may create and/or upload Content while using the Services. You are
+        solely responsible for the content of, and for any harm resulting from,
+        any User-Uploaded Content (including any Third Party's Content) that you
+        post, upload, link to or otherwise make available via the Services,
+        regardless of the form of that content. "The Institution" is not
+        responsible for any public display or misuse of your User-Uploaded
+        Content.
+      </p>
+      <p>
+        "The Institution" does not pre-screen User-Uploaded Content, but "The
+        Institution" has the right (though not the obligation) to refuse or
+        remove any User-Uploaded Content that "The Institution" determines, in
+        its sole discretion, to violate the Terms of Use or any law.
+      </p>
+      <p>
+        You agree that "The Institution" may remove any User-Uploaded Content
+        that "The Institution" in its sole discretion determines to be
+        inappropriate.
+      </p>
+
+      <h4>4.2 Ownership of Content, Right to Post, and License Grants</h4>
+      <p>
+        You retain ownership of and responsibility for Content you create or own
+        and up-load on AiiDAlab.
+      </p>
+      <p>
+        Because you retain ownership of and responsibility for Your Content,
+        "The Institution" needs you to grant "The Institution", and the other
+        AiiDAlab Users, certain legal permissions, listed in Sections 4.4 to
+        4.6. These license grants apply to Your Content. You understand that you
+        will not receive any payment for any of the rights granted in Sections
+        4.4 to 4.6. The licenses you grant hereunder are perpetual. If you
+        upload Content that already comes with a license granting "The
+        Institution" the permissions "The Institution" needs to run the
+        Services, no additional license is required.
+      </p>
+
+      <h4>4.3 Third Party's Content</h4>
+      <p>
+        Before up-loading any Third Party's Content, you must make sure that you
+        have the right to up-load them on AiiDAlab, which is an open
+        environment. So, you hereby warrants that you are either the sole owner
+        of the Content you up-load or, if this is not the case, that you did
+        obtain all authorizations from the lawful owner(s) of such content to
+        up-load it and grant the licenses listed in Sections 4.4 to 4.6.
+      </p>
+      <p>
+        You shall indemnify and hold "The Institution", its partners and any
+        sub-contractor harmless against any claims and damages arising from your
+        up-loading of any Third Party's Content.
+      </p>
+
+      <h4>4.4 License Grant to "The Institution"</h4>
+      <p>
+        "The Institution" needs the legal right to do things such as host Your
+        Content and any Third Party's Content you up-load. You hereby grant "The
+        Institution", its service providers or sub-contractors and "The
+        Institution" legal successors the right to use, store, parse, and
+        display Your Content and any Third Party's Content you up-load, and make
+        incidental copies thereof as necessary to render the Website and provide
+        the Services. This includes the right to do things like make backups;
+        show them to you; use such contents to provide the Services; parse them
+        into a search index or otherwise analyze them on our servers; and
+        perform them, in case Your Content or any Third Party's Content you
+        up-load is something like audio and/or video recordings.
+      </p>
+
+      <h4>4.5 Contributions Under Repository License</h4>
+      <p>
+        Whenever you make a contribution to any AiiDAlab application repository
+        containing notice of a license, you license your contribution under the
+        same terms, and you shall make sure that you have the right to license
+        your contribution under those terms. If you have a separate agreement to
+        license your contributions under different terms, such as a contributor
+        license agreement, that agreement will supersede.
+      </p>
+
+      <h4>4.6 Moral Rights</h4>
+      <p>
+        To the extent Your Content benefits from copyright protection, you
+        retain all moral rights to Your Content that you upload, publish, or
+        submit to any part of the Services, including the rights of integrity
+        and attribution unless otherwise provided in any license you attached to
+        Your Content or in any license attached to another User's Content (see
+        Section 4.5). However, you waive these rights and agree not to assert
+        them against "The Institution", to enable "The Institution" to
+        reasonably exercise the rights granted in Section 4, but not otherwise.
+      </p>
+      <p>
+        To the extent this Section is not enforceable by applicable local law,
+        you grant "The Institution" the rights "The Institution" needs to use
+        Your Content without attribution and to make reasonable adaptations of
+        Your Content as necessary to render the Website and provide the
+        Services.
+      </p>
+
+      <h4>4.7 Private Sections</h4>
+      <p>
+        By default, User-uploaded Content stored in your AiiDAlab account is
+        private. You as the User are in control of providing access to other
+        users or the Public.
+      </p>
+      <p>
+        "The Institution" will use reasonable efforts to protect the contents of
+        private sections from unauthorized use, access, or disclosure. However,
+        "The Institution" extends no warranties as to any unauthorized use,
+        access or disclosure of such content by third parties.
+      </p>
+      <p>
+        "The Institution" employees, or employees of "The Institution"
+        sub-contracting entity operating the supercomputing infrastructure used
+        for some of the Services, may only access the content of your private
+        areas in the following situations:
+      </p>
+      <ul>
+        <li>
+          with your consent, for support reasons. If "The Institution" (or the
+          abovementioned sub-contracting entity) accesses a private repository
+          for support reasons, we will only do so with the User's consent and
+          knowledge; or
+        </li>
+        <li>when access is required for security reasons</li>
+        <li>when accessing it for backup or service maintenance reasons.</li>
+      </ul>
+      <p>
+        If "The Institution" has reason to believe the contents of a private
+        area are in violation of the law or of these Terms of Use, "The
+        Institution" has the right to access, review, and remove them.
+        Additionally, "The Institution" may be compelled by law to disclose the
+        contents of your private repositories.
+      </p>
+
+      <h3>5. Intellectual Property Notice</h3>
+      <h4>5.1. "The Institution"'s Rights to Content</h4>
+      <p>
+        "The Institution" and "The Institution"'s partners, licensors, vendors,
+        agents, and/or content providers retain ownership of all intellectual
+        property rights of any kind related to the Website and Services. "The
+        Institution" reserves all rights that are not expressly granted to you
+        under this Agreement or by law. The look and feel of the Website and
+        Services is copyright of "The Institution" or its respective licensors,
+        vendors, agents and/or content providers. You may not duplicate, copy,
+        or reuse any portion of the HTML/CSS, Javascript, or visual design
+        elements or concepts without express written permission from "The
+        Institution".
+      </p>
+
+      <h4>5.2. "The Institution" Trademarks and Logos</h4>
+      <p>
+        If you'd like to use "The Institution"'s trademarks, logos or names,
+        including &ldquo;AiiDAlab&rdquo; name and logos, you must first obtain
+        the written permission of "The Institution".
+      </p>
+
+      <h4>5.3. License to this Agreement</h4>
+      <p>
+        This Agreement is licensed under the Creative Commons Attribution
+        license. You may use it under the terms of the Creative Commons license.
+      </p>
+
+      <h3>6. Infringement of your Copyrights</h3>
+      <p>
+        If you are a copyright owner and you believe that content on AiiDAlab
+        violates your rights, please contact by emailing
+        <a href="mailto:{{ contact_email }}">{{ contact_email }}</a
+        >. There may be legal consequences for sending a false or frivolous
+        takedown notice. Before sending a takedown request, you must consider
+        legal uses such as fair use and licensed uses.
+      </p>
+      <p>
+        We will terminate the accounts of repeat infringers of this Section.
+      </p>
+      <p>
+        As stated in Sections 4.1 and 4.7, "The Institution" reserves the right
+        to remove any of your Uploaded Content that "The Institution" determines
+        to infringe upon other User's copyrights (or third party's copyrights).
+      </p>
+
+      <h3>7. API Terms</h3>
+      <h4>7.1. Limitation of Liability for API Use</h4>
+      <p>
+        You understand and agree that AiiDAlab is not liable for any direct,
+        indirect, incidental, special, consequential or exemplary damages,
+        including but not limited to damages for loss of profits, goodwill, use,
+        data or other intangible losses (even if AiiDAlab has been advised of
+        the possibility of such damages), resulting from your use of the API or
+        third-party products that access data via the API.
+      </p>
+
+      <h4>7.2. No Abuse or Overuse of the API</h4>
+      <p>
+        Abuse or excessively frequent requests to AiiDAlab via the API may
+        result in the temporary or permanent suspension of your account's access
+        to the API. AiiDAlab, in our sole discretion, will determine abuse or
+        excessive usage of the API. We will make a reasonable attempt to warn
+        you via email prior to suspension.
+      </p>
+      <p>You may not share API tokens to exceed AiiDAlab's rate limitations.</p>
+      <p>
+        You may not use the API to download data or Content from AiiDAlab for
+        spamming purposes, including for the purposes of selling AiiDAlab users'
+        personal information, such as to recruiters, headhunters, and job
+        boards.
+      </p>
+      <p>
+        All use of the AiiDAlab API is subject to these Terms of Services and
+        the AiiDAlab Privacy Policy. AiiDAlab may offer subscription-based
+        access to its API for those Users who require high-throughput access or
+        access that would result in resale of AiiDAlab's Services.
+      </p>
+
+      <h4>7.3. AiiDAlab May Terminate Your Use of the API</h4>
+      <p>
+        We reserve the right at any time to modify or discontinue, temporarily
+        or permanently, your access to the API or any part of it with or without
+        notice.
+      </p>
+
+      <h3>8. Cancellation and Termination</h3>
+      <h4>8.1. Account Cancellation</h4>
+      <p>
+        You can cancel your account at any time by contacting the AiiDAlab at
+        <a href="mailto:{{ contact_email }}">{{ contact_email }}</a
+        >.
+      </p>
+
+      <h4>8.2. Upon Cancellation</h4>
+      <p>
+        "The Institution" will retain and use your information as necessary to
+        comply with its legal obligations, resolve disputes, and enforce
+        agreements, but barring legal requirements, "The Institution" will
+        delete your full profile and the Content in your Private Area if any,
+        within 90 days of cancellation or termination; however, though some
+        information may remain in backups. This information cannot be recovered
+        once your account is cancelled. Since the aim of AiiDAlab is to
+        disseminate scientific research results in an open science framework,
+        your Uploaded Content on public pages of AiiDAlab will not be removed
+        upon cancellation of your account (unless otherwise set forth in these
+        Terms of Use).
+      </p>
+
+      <h4>8.3. "The Institution" Termination Rights</h4>
+      <p>
+        "The Institution" has the right to suspend or terminate your access to
+        all or any part of the Website or Services at any time. You hereby waive
+        any claim, demands and damages against "The Institution" and its service
+        providers in case of such a termination.
+      </p>
+
+      <h4>8.4. Survival</h4>
+      <p>
+        All provisions of this Agreement which by their nature should survive
+        termination will survive termination, including, without limitation,
+        ownership provisions, warranty disclaimers, indemnity, and limitations
+        of liability.
+      </p>
+
+      <h3>9. Communications with AiiDAlab</h3>
+      <h4>9.1. Electronic Communication Required</h4>
+      <p>
+        For contractual purposes, you (1) consent to receive communications from
+        "The Institution" in an electronic form via the email address you have
+        submitted or via the Services; and (2) agree that the Terms of Use and
+        any agreements, notices, disclosures, and other communications that "The
+        Institution" provides in connection with AiiDAlab to you electronically
+        satisfy any legal requirement that those communications would satisfy if
+        they were on paper. This section does not affect any non-waivable rights
+        by law.
+      </p>
+
+      <h4>9.2. Legal Notice to AiiDAlab</h4>
+      <p>
+        Legal notice to "The Institution" must be in writing and served to:
+        {{ institution.name.full }}, {{ institution.address }} or to
+        <a href="mailto:{{ contact_email }}">{{ contact_email }}</a
+        >.
+      </p>
+
+      <h4>9.3. No Phone Support</h4>
+      <p>
+        "The Institution" only offers for AiiDAlab support via email,
+        in-Services communications, and electronic messages. There is no
+        telephone support.
+      </p>
+
+      <h3>10. Disclaimer of Warranties</h3>
+      <p>
+        AiiDAlab and its subcontractors provide the Website and the Services
+        &ldquo;as is&rdquo; and &ldquo;as available,&rdquo; without warranty of
+        any kind. Without limiting this, "The Institution" expressly disclaims
+        all warranties, whether express, implied or statutory, regarding the
+        Website and the Services including without limitation any warranty of
+        merchantability, fitness for a particular purpose, title, security,
+        accuracy and non-infringement.
+      </p>
+      <p>
+        AiiDAlab and its subcontractor do not warrant that the Services will
+        meet your requirements; that the Services will be uninterrupted, timely,
+        secure, or error-free; that the information provided through the
+        Services is accurate, reliable or correct; that any defects or errors
+        will be corrected; that the Services will be available at any particular
+        time or location; or that the Services is free of viruses or other
+        harmful components. You assume full responsibility and risk of loss
+        resulting from your downloading, uploading and/or use of files,
+        information, content or other material obtained from the Services.
+      </p>
+
+      <h3>11. Limitation of Liability</h3>
+      <p>
+        You understand and agree that "The Institution" (and its subcontractors)
+        will not be liable to you or any third party for any loss of profits,
+        use, goodwill, or data, or for any incidental, indirect, special,
+        consequential or exemplary damages, however arising, that result from
+      </p>
+      <ul>
+        <li>the use, disclosure, or display of your User-Uploaded Content;</li>
+        <li>your use or inability to use the Services;</li>
+        <li>
+          any modification, price change, suspension or discontinuance of the
+          Services;
+        </li>
+        <li>
+          the Services generally or the software or systems that make the
+          Services available;
+        </li>
+        <li>
+          unauthorized access to or alterations of your transmissions or data;
+        </li>
+        <li>statements or conduct of any third party on the Services;</li>
+        <li>
+          any other user interactions that you input or receive through your use
+          of the Services; or
+        </li>
+        <li>any other matter relating to the Services.</li>
+      </ul>
+      <p>
+        "The Institution" and its subcontractors liability is limited whether or
+        not we have been informed of the possibility of such damages, and even
+        if a remedy set forth in these Terms of Use is found to have failed of
+        its essential purpose. Should "The Institution" liability limitations
+        not be enforceable under imperative law, then the maximum liability of
+        "The Institution" in connection with the Services or the use of the
+        Website shall be limited to the smaller of the amount paid by the User
+        over the last six months or five hundred Swiss francs.
+      </p>
+
+      <h3>12. Release and Indemnification</h3>
+      <p>
+        If you have a dispute with one or more Users, you agree to release
+        AiiDAlab (and its subcontractors) from any and all claims, demands and
+        damages (actual and consequential) of every kind and nature, known and
+        unknown, arising out of or in any way connected with such disputes.
+      </p>
+      <p>
+        You agree to indemnify and hold "The Institution", its partners and any
+        sub-contractor, harmless from and against any and all claims,
+        liabilities, and expenses, including attorneys' fees, arising out of
+        your use of the Website and the Services, including but not limited to
+        your violation of the Terms of Use.
+      </p>
+
+      <h3>13. Changes to These Terms of Use</h3>
+      <p>
+        "The Institution" reserves the right, at its sole discretion, to amend
+        these Terms of Use at any time and will update them in the event of any
+        such amendments. We will notify the Users of material changes to these
+        Terms of Use, such as price changes, at least 30 days prior to the
+        change taking effect by posting a notice on AiiDAlab Website and you
+        will have the right to cancel your account within 30 days from such
+        notice. For any modification, your continued use of the Website
+        constitutes agreement to our revisions of these Terms of Use.
+      </p>
+
+      <h3>14. Changes to the Website</h3>
+      <p>
+        We reserve the right at any time and from time to time to modify the
+        Website (or any part of it) with or without notice.
+      </p>
+
+      <h3>15. Miscellaneous</h3>
+      <h4>15.1. Governing Law &mdash; Place of Jurisdiction</h4>
+      <p>
+        These Terms of Use between you and "The Institution", any access to or
+        use of the Website or the Services, and any claims raised in connection
+        with the Terms of Use or the Website or the Services, are governed by
+        Swiss law, without regard to conflict of law provisions. You agree to
+        submit to the exclusive jurisdiction of the cantonal court of
+        {{ court }}.
+      </p>
+
+      <h4>15.2. Non-Assignability</h4>
+      <p>
+        "The Institution" may assign or delegate these Terms of Use and/or the
+        AiiDAlab Privacy Policy in whole or in part, to any person or entity at
+        any time with or without your consent, including the license grants in
+        Section 4. You may not assign or delegate any rights or obligations
+        under these Terms of Use without "The Institution" prior written
+        consent, and any unauthorized assignment and delegation by you is void.
+      </p>
+
+      <h4>15.3. Severability, No Waiver, and Survival</h4>
+      <p>
+        If any part of these Terms of Use is held invalid or unenforceable, that
+        portion will be construed to reflect the parties' original intent. The
+        remaining portions will remain in full force and effect. Any failure on
+        the part of AiiDAlab to enforce any provision of these Terms of Use will
+        not be considered a waiver of our right to enforce such provision. "The
+        Institution" rights under this Agreement will survive any termination of
+        these Terms of Use.
+      </p>
+
+      <h4>15.4. Nature of Agreement; Amendments; Complete Agreement</h4>
+      <p>
+        The Terms of Use constitute a bilateral agreement between you and "The
+        Institution" for your use of the Website and/or the Services. These
+        Terms of Use may only be modified by a written amendment signed by an
+        authorized representative of "The Institution", or by the posting by
+        "The Institution" of a revised version in accordance with Section 13.
+      </p>
+      <p>
+        These Terms of Use, together with the AiiDAlab Privacy Policy, represent
+        the complete and exclusive statement of the agreement between you and
+        "The Institution" on the subject matter herein. Such agreement
+        supersedes any proposal or prior agreement oral or written, and any
+        other communications between you and "The Institution" or AiiDAlab
+        relating to the subject matter of these terms including any
+        confidentiality or nondisclosure agreements.
+      </p>
+
+      <h4>15.5. Copyright notice</h4>
+      <p>
+        This work &ldquo;AiiDAlab Terms of Use&rdquo; is a derivative work of
+        &ldquo;<a
+          href="https://help.github.com/articles/github-terms-of-service/"
+          target="_blank"
+          >GitHub Terms of Service</a
+        >&rdquo; by GitHub Inc. used under the
+        <a href="https://creativecommons.org/licenses/by/4.0/" target="_blank"
+          >Creative Common Attribution License</a
+        >. This work is licensed under Creative Common Attribution License by
+        {{ institution.name.full }}.
+      </p>
+    </div>
+    <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/js/bootstrap.bundle.min.js"></script>
+  </body>
+</html>

--- a/basehub/values.yaml.j2
+++ b/basehub/values.yaml.j2
@@ -4,7 +4,7 @@ jupyterhub:
         https:
             enabled: true
             hosts:
-                - {{ 'staging-demo' if environ('K8S_NAMESPACE')=='staging' else 'demo' }}.aiidalab.io
+                - edan-aiidalab.aiidalab.io
             letsencrypt:
                 contactEmail: aiidalab@materialscloud.org
     singleuser:
@@ -45,19 +45,31 @@ jupyterhub:
                 - mountPath: /etc/jupyter
                   name: etc-jupyter
     hub:
+        readinessProbe:
+            enabled: true
+            initialDelaySeconds: 5  # Increase delay to allow Hub to start
+            periodSeconds: 10        # Frequency of the probe check
+            failureThreshold: 5      # Allow 5 failures before marking unhealthy
+            timeoutSeconds: 5        # Timeout for the probe check
         db:
             pvc:
                 storageClassName: default
                 storage: 1Gi
         extraConfig:
+            customTemplateVars: |
+                c.JupyterHub.template_vars = {
+                    'include_policies': {{ environ('INCLUDE_POLICIES') }},
+                }
             00-logo: |
                 c.JupyterHub.logo_file = "/usr/local/share/jupyterhub/static/external/aiidalab-wide-logo.png"
             02-spawner: |
                 c.KubeSpawner.http_timeout = 300
             03-templates: |
                 c.JupyterHub.template_paths.append('/etc/jupyterhub/templates')
-            04-faq-about-handler: |
+            04-navigation-handler: |
                 from jupyterhub.handlers import BaseHandler
+
+                include_policies = {{ environ('INCLUDE_POLICIES') }}
 
                 class AboutHandler(BaseHandler):
                     def get(self):
@@ -67,10 +79,26 @@ jupyterhub:
                     def get(self):
                         self.write(self.render_template("faq.html", sync=True))
 
-                c.JupyterHub.extra_handlers.extend([
-                    (r"about", AboutHandler),
-                    (r"faq", FAQHandler),
-                ])
+                if include_policies:
+                    class TermsOfUseHandler(BaseHandler):
+                        def get(self):
+                            self.write(self.render_template("terms-of-use.html", sync=True))
+
+                    class PrivacyPolicyHandler(BaseHandler):
+                        def get(self):
+                            self.write(self.render_template("privacy-policy.html", sync=True))
+
+                routes = [(r"about", AboutHandler)]
+                if include_policies:
+                    routes.extend(
+                        [
+                            (r"terms-of-use", TermsOfUseHandler),
+                            (r"privacy-policy", PrivacyPolicyHandler),
+                        ]
+                    )
+                routes.append((r"faq", FAQHandler))
+                c.JupyterHub.extra_handlers.extend(routes)
+
             20-announce: |
                 c.JupyterHub.template_vars = {
                     'announcement_login': 'The site is in beta testing. Please report any issue you might encounter in the <a href="https://github.com/unkcpz/aiidalab-demo-server/issues/new">AiiDAlab Demo GitHub repository</a>.',

--- a/basehub/values.yaml.j2
+++ b/basehub/values.yaml.j2
@@ -4,7 +4,7 @@ jupyterhub:
         https:
             enabled: true
             hosts:
-                - edan-aiidalab.aiidalab.io
+                - {{ 'staging-demo' if environ('K8S_NAMESPACE') == 'staging' else 'demo' }}.aiidalab.io
             letsencrypt:
                 contactEmail: aiidalab@materialscloud.org
     singleuser:


### PR DESCRIPTION
This PR adds the following:
- Policy document Jinja templates (terms of use, privacy policy)
- A configurations file to provide the template variables
- A script to generate the HTML documents and flag the `INCLUDE_POLICIES` environment variable to `True`

The environment variable is used to determine if the relevant navigation items should be included in the landing page

![image](https://github.com/user-attachments/assets/1f8de287-8ddd-4441-9e4e-31e39153acfa)
