### PR TITLE
Implement countdown feature and include in deployment

### DIFF
--- a/README.md
+++ b/README.md
@@ -219,6 +219,8 @@ The following environment variables are required to be set:
 - `OAUTH_CLIENT_ID`: The client ID of the GitHub app.
 - `OAUTH_CLIENT_SECRET`: The client secret of the GitHub app.
 - `OAUTH_CALLBACK_URL`: The callback URL of the GitHub app.
+- `PYTHON_MINOR_VERSION`: The version of python used in the aiidalab image used by the deployment
+- `CONTAINER_LIFETIME`: The lifetime of the container (cull time defined by the kubernetes protocol)
 
 We use GitHub oauthenticator, the users will be able to login with their GitHub account.
 The authentication is created using the `aiidalab` org with app name `aiidalab-demo-production` and `aiidalab-demo-staging` for the production and staging environments respectively.

--- a/basehub/files/static/custom/aiidalab_uptime.py
+++ b/basehub/files/static/custom/aiidalab_uptime.py
@@ -1,0 +1,34 @@
+import re
+import subprocess
+
+from notebook.base.handlers import IPythonHandler
+from notebook.utils import url_path_join
+
+
+class UptimeHandler(IPythonHandler):
+    def get(self):
+        try:
+            output = subprocess.check_output(["ps", "-p", "1", "-o", "etime="])
+            uptime = output.decode("utf-8").strip()
+            seconds = self._parse_uptime_to_seconds(uptime)
+            self.finish({"uptime": seconds})
+        except Exception as e:
+            self.set_status(500)
+            self.finish({"error": str(e)})
+
+    @staticmethod
+    def _parse_uptime_to_seconds(uptime: str) -> int:
+        # Supports MM:SS, HH:MM:SS, or D-HH:MM:SS formats
+        # Captures days*, hours*, minutes, and seconds -> *optional
+        match = re.match(r"(?:(\d+)-)?(?:(\d+):)?(\d+):(\d+)", uptime)
+        if not match:
+            raise ValueError(f"Unrecognized etime format: {uptime}")
+
+        days, hours, minutes, seconds = match.groups(default="0")
+        return int(days) * 86400 + int(hours) * 3600 + int(minutes) * 60 + int(seconds)
+
+
+def load_jupyter_server_extension(nbapp):
+    web_app = nbapp.web_app
+    route = url_path_join(web_app.settings["base_url"], "/uptime")
+    web_app.add_handlers(".*", [(route, UptimeHandler)])

--- a/basehub/files/static/custom/custom.css
+++ b/basehub/files/static/custom/custom.css
@@ -1,0 +1,33 @@
+#culling-countdown {
+  position: sticky;
+  top: 0;
+  left: 0;
+  width: 100%;
+  background-color: #0078d4;
+  color: white;
+  text-align: center;
+  padding: 8px;
+  font-size: 18px;
+  font-weight: bold;
+  z-index: 9999;
+}
+
+#shutdown-warning,
+#save-info {
+  display: none;
+}
+
+#shutdown-warning {
+  font-size: 20px;
+}
+
+#save-info {
+  font-size: 16px;
+  text-align: center;
+  font-weight: normal;
+  font-size: 18px;
+}
+
+#culling-timer {
+  margin-left: 5px;
+}

--- a/basehub/files/static/custom/custom.js
+++ b/basehub/files/static/custom/custom.js
@@ -1,0 +1,117 @@
+require(["base/js/namespace", "base/js/events"], (Jupyter, events) => {
+  const parseLifetimeToMs = (str) => {
+    // Supports MM:SS, HH:MM:SS, or D-HH:MM:SS formats
+    // Captures days*, hours*, minutes, and seconds -> *optional
+    const regex = /(?:(\d+)-)?(?:(\d+):)?(\d+):(\d+)/;
+    const match = regex.exec(str.trim());
+
+    if (!match) {
+      console.warn("Invalid lifetime format:", str);
+      return null;
+    }
+
+    const [_, days, hours, minutes, seconds] = match.map((v) => Number(v) || 0);
+
+    const totalSeconds = days * 86400 + hours * 3600 + minutes * 60 + seconds;
+    return totalSeconds * 1000;
+  };
+
+  const insertCountdown = (remainingMs) => {
+    if (document.getElementById("culling-countdown")) {
+      return;
+    }
+
+    const banner = document.createElement("div");
+    banner.id = "culling-countdown";
+
+    const shutdownWarning = document.createElement("div");
+    shutdownWarning.id = "shutdown-warning";
+    shutdownWarning.innerHTML = "⚠️ Shutdown imminent! ⚠️";
+    banner.appendChild(shutdownWarning);
+
+    const countdown = document.createElement("div");
+    countdown.id = "countdown";
+    countdown.innerHTML = `Session time remaining: `;
+    const timer = document.createElement("span");
+    timer.id = "culling-timer";
+    timer.innerHTML = "Calculating...";
+    countdown.appendChild(timer);
+    banner.appendChild(countdown);
+
+    const saveInfo = document.createElement("div");
+    saveInfo.id = "save-info";
+    saveInfo.innerHTML = `
+      Consider saving your work using the <b>File Manager</b> or the <b>Terminal</b>
+    `;
+    banner.appendChild(saveInfo);
+
+    const startTime = Date.now();
+    const endTime = startTime + remainingMs;
+
+    const formatTime = (seconds) => {
+      const hrs = `${Math.floor(seconds / 3600)}`.padStart(2, "0");
+      const mins = `${Math.floor((seconds % 3600) / 60)}`.padStart(2, "0");
+      const secs = `${Math.floor(seconds % 60)}`.padStart(2, "0");
+      return `${hrs}:${mins}:${secs}`;
+    };
+
+    const updateTimer = () => {
+      const timeLeft = (endTime - Date.now()) / 1000;
+      if (timeLeft < 0) {
+        clearInterval(interval);
+        return;
+      }
+      if (timeLeft < 1800) {
+        banner.style.backgroundColor = "#DAA801";
+        saveInfo.style.display = "block";
+      }
+      if (timeLeft < 300) {
+        banner.style.backgroundColor = "red";
+        shutdownWarning.style.display = "block";
+        shutdownWarning.innerHTML = "⚠️ Shutdown imminent ⚠️";
+      }
+      timer.innerHTML = formatTime(timeLeft);
+    };
+
+    updateTimer();
+    const interval = setInterval(updateTimer, 1000);
+
+    const container = document.getElementById("header");
+    if (container) {
+      container.parentNode.insertBefore(banner, container);
+    }
+  };
+
+  const loadCountdown = async () => {
+    const baseUrl = Jupyter.notebook.base_url;
+    try {
+      const [configResponse, uptimeResponse] = await Promise.all([
+        fetch(`${baseUrl}/static/custom/config.json`),
+        fetch(`${baseUrl}/uptime`),
+      ]);
+
+      const config = await configResponse.json();
+      const uptimeData = await uptimeResponse.json();
+
+      if (!config.ephemeral) {
+        return;
+      }
+
+      if (!config.lifetime) {
+        console.warn("Missing `lifetime` in config file");
+        return;
+      }
+
+      const lifetimeMs = parseLifetimeToMs(config.lifetime);
+      const uptimeMs = uptimeData.uptime * 1000;
+      const remaining = lifetimeMs - uptimeMs;
+
+      insertCountdown(Math.max(0, remaining));
+    } catch (err) {
+      console.error("Countdown init failed:", err);
+    }
+  };
+
+  events.on("app_initialized.NotebookApp", loadCountdown);
+  loadCountdown();
+});

--- a/basehub/templates/hub-configmap.yaml
+++ b/basehub/templates/hub-configmap.yaml
@@ -29,3 +29,29 @@ data:
   {{- end }}
   {{- end }}
   {{- (.Files.Glob "files/etc/jupyter/*").AsConfig | nindent 2 }}
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: notebook-static-custom
+data:
+  {{- (.Files.Glob "files/static/custom/*").AsConfig | nindent 2 }}
+  config.json: |
+    {
+      "ephemeral": {{ ternary "1" "0" (hasKey .Values.jupyterhub.singleuser.extraEnv "CONTAINER_LIFETIME") }},
+      "lifetime": {{ .Values.jupyterhub.singleuser.extraEnv.CONTAINER_LIFETIME | default "" | quote }}
+    }
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: aiidalab-uptime
+data:
+  aiidalab_uptime.json: |
+    {
+      "NotebookApp": {
+        "nbserver_extensions": {
+          "notebook.static.custom.aiidalab_uptime": true
+        }
+      }
+    }

--- a/basehub/values.yaml.j2
+++ b/basehub/values.yaml.j2
@@ -16,6 +16,7 @@ jupyterhub:
             - start-singleuser.sh
         extraEnv:
             JUPYTERHUB_SINGLEUSER_APP: notebook.notebookapp.NotebookApp
+            LIFETIME: "{{ environ('CONTAINER_LIFETIME') }}"
         cpu:
             guarantee: 1.5
             limit: 1.5
@@ -37,6 +38,9 @@ jupyterhub:
                 - name: etc-jupyter
                   configMap:
                       name: user-etc-jupyter
+                - name: notebook-static-custom
+                  configMap:
+                      name: notebook-static-custom
             extraVolumeMounts:
                 - mountPath: /etc/jupyterhub/templates
                   name: hub-templates
@@ -44,6 +48,8 @@ jupyterhub:
                   name: hub-external
                 - mountPath: /etc/jupyter
                   name: etc-jupyter
+                - mountPath: /opt/conda/lib/python{{ environ('PYTHON_MINOR_VERSION') }}/site-packages/notebook/static/custom
+                  name: notebook-static-custom
     hub:
         readinessProbe:
             enabled: true


### PR DESCRIPTION
This PR migrates https://github.com/aiidalab/aiidalab-docker-stack/pull/525 to the demo server repo for production testing. Further details and discussion can be found in the original PR. One major difference is that endpoints for `config.json` and `uptime` are now referenced w.r.t `Jupyter.notebook.baseUrl`, which works in any environment.